### PR TITLE
Added variable definition via define keyword

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,12 @@ Unit tests can be executed using CTest.
  - Mathematical functions, `+`, `-`, etc.
  - A small set of built in functions, such as `list`, `list?`, `length`.
  - Building and evaluating lambda functions.
+ - Top level definitions using `define`.
 
 ## TODO
 
- - Definition of variables - lambdas can only be immediately invoked at
-   the moment.
+ - Local binding of variables via `let`.
+ - Abbreviated forms of lambda definitions via `define`.
  - Garbage collection. Nothing is reclaimed at the moment.
  - Syntactic extensions.
  - Lots of other things that I don't know I'm even missing yet.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -170,6 +170,33 @@ static expr_t b_lambda(crisp_t *crisp, expr_t operands, env_t *env)
   return lambda_value(crisp, car(operands), cdr(operands), env);
 }
 
+static expr_t b_define(crisp_t *crisp, expr_t operands, env_t *env)
+{
+  CHECK_MIN_ARITY(crisp, operands, 1U);
+
+  // Special form - the first operand is not evaluated but must be an atom.
+  expr_t key = car(operands);
+  CHECK_OPERAND(crisp, is_atom(key), key, "must be an atom");
+
+  // The unassigned value in crisp is nil.
+  expr_t value = nil_value();
+
+  // If a second operand is present, evaluate it as the value for the
+  // definition.
+  if (length(operands) == 2)
+  {
+    value = crisp_eval(crisp, car(cdr(operands)), env);
+  }
+  else
+  {
+    printf("Crisp does not support abbreviated lambdas.");
+    crisp_eval_error(crisp, "Unsupport form of define.");   
+  }
+
+  env_set(env_get_top_level(env), as_atom(key), value);
+  return nil_value();
+}
+
 void register_builtins(crisp_t *crisp)
 {
   env_t *env = root_env(crisp);
@@ -190,4 +217,5 @@ void register_builtins(crisp_t *crisp)
   env_set(env, intern(crisp, "number?"), fn_value(&b_number));
   env_set(env, intern(crisp, "string?"), fn_value(&b_string));
   env_set(env, intern(crisp, "lambda"), fn_value(&b_lambda));
+  env_set(env, intern(crisp, "define"), fn_value(&b_define));
 }

--- a/src/environment.c
+++ b/src/environment.c
@@ -17,6 +17,21 @@ env_t *env_init_child(env_t *parent)
   return env;
 }
 
+bool env_is_top_level(env_t* env)
+{
+  return (env->parent == NULL);
+}
+
+env_t* env_get_top_level(env_t* env)
+{
+  while(!env_is_top_level(env))
+  {
+    env = env->parent;
+  }
+
+  return env;
+}
+
 void env_free(env_t *env)
 {
   if(env != NULL)

--- a/src/environment.h
+++ b/src/environment.h
@@ -12,6 +12,9 @@ struct env_t
 
 env_t* env_init();
 env_t* env_init_child(env_t* parent);
+bool env_is_top_level(env_t* env);
+
+env_t* env_get_top_level(env_t* env);
 void env_free(env_t* env);
 
 bool env_get(env_t* env, const char* name, value_t** value);

--- a/test/environment_test.c
+++ b/test/environment_test.c
@@ -46,6 +46,16 @@ static int env_test(test_fixture_t* fixture)
   env_t* child = env_init_child(root);
   env_t* grand_child = env_init_child(child);
 
+  // Top level testing
+  TEST_ASSERT(env_is_top_level(root));
+  TEST_ASSERT(!env_is_top_level(child));
+  TEST_ASSERT(!env_is_top_level(grand_child));
+
+  // Top level (root) retrieval
+  TEST_ASSERT(env_get_top_level(root) == root);
+  TEST_ASSERT(env_get_top_level(child) == root);
+  TEST_ASSERT(env_get_top_level(grand_child) == root);
+
   // No values in the envs
   TEST_ASSERT(env_get(root, fixture->v1, &v) == false);
   TEST_ASSERT(env_get(root, fixture->v2, &v) == false);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -1,16 +1,25 @@
 #include "simple_test.h"
+#include "interpreter.h"
 
 #define TEST_PARSE(src, exp)                                   \
-  if (execute_crisp_code(src, exp, __FILE__, __LINE__,         \
+  {                                                            \
+    crisp_t *crisp = init_interpreter();                       \
+    if (execute_crisp_code(crisp, src, exp, __FILE__, __LINE__,\
                          false, false, false) != PASS_CODE) {  \
-    return FAIL_CODE;                                          \
-  }
+      return FAIL_CODE;                                        \
+    }                                                          \
+  free_interpreter(crisp);                                     \
+}
 
 #define TEST_PARSE_FAILURE(src)                                \
-  if (execute_crisp_code(src, "", __FILE__, __LINE__,          \
+  {                                                            \
+    crisp_t *crisp = init_interpreter();                       \
+    if (execute_crisp_code(crisp, src, "", __FILE__, __LINE__, \
                          true, false, false) != PASS_CODE) {   \
-    return FAIL_CODE;                                          \
-  }
+      return FAIL_CODE;                                        \
+    }                                                          \
+  free_interpreter(crisp);                                     \
+}
 
 int main(int argc, char** argv)
 {

--- a/test/scanner_test.c
+++ b/test/scanner_test.c
@@ -28,11 +28,12 @@ int main(int argc, char** argv)
   (void)argc;
   (void)argv;
   {
-    run_scanner("(+ \"abc\")");
+    run_scanner("(+ \"abc\") 5");
     TEST_ASSERT(NTT() == TOKEN_LEFT_PAREN);
     TEST_ASSERT(NTT() == TOKEN_IDENTIFIER);
     TEST_ASSERT(NTT() == TOKEN_STRING);
     TEST_ASSERT(NTT() == TOKEN_RIGHT_PAREN);
+    TEST_ASSERT(NTT() == TOKEN_NUMBER);
     TEST_ASSERT(NTT() == TOKEN_EOF);
   }
 

--- a/test/simple_test.h
+++ b/test/simple_test.h
@@ -39,6 +39,7 @@
 #endif
 
 int execute_crisp_code(
+  crisp_t* crisp,
   const char* src, 
   const char* expected, 
   const char* file_name, 
@@ -46,3 +47,9 @@ int execute_crisp_code(
   bool expect_parse_fail,
   bool run_eval,
   bool expect_eval_fail);
+
+int compare_crisp_value(
+  expr_t value,
+  const char* expected,
+  const char* file_name, 
+  int line);


### PR DESCRIPTION
define can be used to bind an expression to a name in the top level environment. Currently only the following two forms are supported:

    syntax: (define var expr)
    syntax: (define var)

The abbreviated lambda syntax is not supported.

Simple Test unit testing framework needed to be modified to allow the interpreter instance to persist between calls to TEST_EVAL. This is to allow definitions to be first defined and then evaluated.